### PR TITLE
Make commands lazy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/amqp.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/amqp.xml
@@ -7,16 +7,9 @@
     <services>
         <defaults public="false" />
 
-        <service id="amqp.broker_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
-            <tag name="container.service_locator" />
-            <argument type="collection">
-                <argument key="Symfony\Component\Amqp\Broker" type="service" id="amqp.broker" />
-            </argument>
-        </service>
-
         <service id="amqp.command.move" class="Symfony\Component\Amqp\Command\AmqpMoveCommand">
-            <tag name="console.command" />
-            <argument type="service" id="amqp.broker_locator" />
+            <tag name="console.command" command="amqp:move" />
+            <argument type="service" id="amqp.broker" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/worker.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/worker.xml
@@ -13,12 +13,12 @@
         </service>
 
         <service id="worker.command.list" class="Symfony\Component\Worker\Command\WorkerListCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="worker:list" />
             <argument /> <!-- worker names -->
         </service>
 
         <service id="worker.command.run" class="Symfony\Component\Worker\Command\WorkerRunCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="worker:run" />
             <argument type="service" id="worker.worker_locator" />
             <argument /> <!-- process title prefix -->
             <argument /> <!-- worker names -->


### PR DESCRIPTION
So that we don't need a container just for one dependency and commands can be inlined in the container. This will require to rebase the base branch on symfony/symfony/3.4